### PR TITLE
fix: ensure reading from card with `readFromCard.py` works

### DIFF
--- a/clearCard.py
+++ b/clearCard.py
@@ -1,6 +1,6 @@
 
 import json, hashlib
-from smartcards.card import CardInterface
+from smartcards.core import CardInterface
 
 import time
 time.sleep(2)

--- a/readFromCard.py
+++ b/readFromCard.py
@@ -1,6 +1,6 @@
 
 import json, hashlib
-from smartcards.card import CardInterface
+from smartcards.core import CardInterface
 
 import time
 time.sleep(2)

--- a/readFromCard.py
+++ b/readFromCard.py
@@ -5,12 +5,22 @@ from smartcards.core import CardInterface
 import time
 time.sleep(2)
 
+def print_bytes(b: bytes):
+    try:
+        s = b.decode('utf-8')
+        if s.isprintable():
+            print(s)
+        else:
+            print(s.__str__())
+    except:
+        print(b)
+
 short_value, has_long_value = CardInterface.read()
-print(short_value.decode('utf-8'))
+print_bytes(short_value)
 
 if has_long_value:
     print("reading long value...")
     long_value = CardInterface.read_long()
-    print(long_value.decode('utf-8'))
+    print_bytes(long_value)
 
 print("done")

--- a/writeClerkCard.py
+++ b/writeClerkCard.py
@@ -1,6 +1,6 @@
 
 import json, hashlib, sys
-from smartcards.card import CardInterface
+from smartcards.core import CardInterface
 
 # wait for the reader to wake up and notice the card
 import time

--- a/writeToCard.py
+++ b/writeToCard.py
@@ -1,6 +1,6 @@
 
 import json, hashlib
-from smartcards.card import CardInterface
+from smartcards.core import CardInterface
 
 import time
 time.sleep(2)

--- a/writeVoterCard.py
+++ b/writeVoterCard.py
@@ -1,6 +1,6 @@
 
 import json, hashlib
-from smartcards.card import CardInterface
+from smartcards.core import CardInterface
 
 import time
 time.sleep(2)


### PR DESCRIPTION
This script failed when the bytes in either short or long value couldn't be interpreted as a utf-8 string. Now, we print a string for each if we can, but fall back to printing the raw bytes if needed. Additionally, if the bytes _are_ a valid utf-8 string but that string is not printable, use the inspected version of the string rather than printing with blanks for unprintable characters.

Closes #38