### PR TITLE
Use jsonify for returning results.

### DIFF
--- a/.postman/postman_collection.json
+++ b/.postman/postman_collection.json
@@ -1,0 +1,88 @@
+{
+	"info": {
+		"_postman_id": "a4e3b4f6-3cfa-43cb-8135-fe7ca5fb179c",
+		"name": "VotingWorks CARD",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get Card",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "javascript"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{scheme}}://{{host}}:{{port}}/card/read",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"card",
+						"read"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Card Long Data",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "javascript"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{scheme}}://{{host}}:{{port}}/card/read_long",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"card",
+						"read_long"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/.postman/postman_environment.json
+++ b/.postman/postman_environment.json
@@ -1,0 +1,24 @@
+{
+	"id": "55f04ab4-cc57-493a-8ae0-db24abfebb77",
+	"name": "VotingWorks - Card",
+	"values": [
+		{
+			"key": "scheme",
+			"value": "http",
+			"enabled": true
+		},
+		{
+			"key": "host",
+			"value": "localhost",
+			"enabled": true
+		},
+		{
+			"key": "port",
+			"value": "3001",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2019-12-06T13:35:55.945Z",
+	"_postman_exported_using": "Postman/7.10.0"
+}

--- a/smartcards/core.py
+++ b/smartcards/core.py
@@ -3,7 +3,7 @@ import json
 import os
 import base64
 
-from flask import Flask, send_from_directory, request
+from flask import Flask, send_from_directory, request, jsonify
 
 from smartcard.System import readers
 from smartcard.util import toHexString, toASCIIBytes, toASCIIString
@@ -22,36 +22,36 @@ app = Flask(__name__)
 def card_read():
     card_bytes, long_value_exists = CardInterface.read()
     if card_bytes is None:
-        return json.dumps({"present": False})
+        return jsonify({"present": False})
 
     card_data = card_bytes.decode('utf-8')
     if card_data:
-        return json.dumps({"present": True, "shortValue": card_data, "longValueExists": long_value_exists})
+        return jsonify({"present": True, "shortValue": json.loads(card_data), "longValueExists": long_value_exists})
     else:
-        return json.dumps({"present": True})
+        return jsonify({"present": True})
 
 
 @app.route('/card/read_long')
 def card_read_long():
     long_bytes = CardInterface.read_long()
     if long_bytes:
-        return json.dumps({"longValue": long_bytes.decode('utf-8')})
+        return jsonify(json.loads(long_bytes.decode('utf-8')))
     else:
-        return json.dumps({})
+        return jsonify({})
 
 
 @app.route('/card/write', methods=["POST"])
 def card_write():
     content = request.data
     rv = CardInterface.write(content)
-    return json.dumps({"success": rv})
+    return jsonify({"success": rv})
 
 
 @app.route('/card/write_and_protect', methods=["POST"])
 def card_write_and_protect():
     content = request.data
     rv = CardInterface.write(content, write_protect=True)
-    return json.dumps({"success": rv})
+    return jsonify({"success": rv})
 
 
 @app.route('/card/write_short_and_long', methods=["POST"])
@@ -60,29 +60,29 @@ def card_write_short_and_long():
     long_value = request.form['long_value']
     rv = CardInterface.write_short_and_long(
         short_value.encode('utf-8'), long_value.encode('utf-8'))
-    return json.dumps({"success": rv})
+    return jsonify({"success": rv})
 
 
 @app.route('/card/read_long_b64', methods=["GET"])
 def card_read_long_b64():
     long_bytes = CardInterface.read_long()
     if long_bytes:
-        return json.dumps({"longValue": base64.b64encode(long_bytes).decode('ascii')})
+        return jsonify({"longValue": base64.b64encode(long_bytes).decode('ascii')})
     else:
-        return json.dumps({"longValue": None})
+        return jsonify({"longValue": None})
 
 
 @app.route('/card/write_long_b64', methods=["POST"])
 def card_write_long_b64():
     long_value = request.form["long_value"]
     rv = CardInterface.write_long(base64.b64decode(long_value))
-    return json.dumps({"success": rv})
+    return jsonify({"success": rv})
 
 
 @app.route('/card/write_protect_override', methods=["POST"])
 def card_write_protect_override():
     CardInterface.override_protection()
-    return json.dumps({"success": True})
+    return jsonify({"success": True})
 
 
 @app.route('/')


### PR DESCRIPTION
Binary decode into objects instead of strings using json.loads.  This makes the responses deserialize out into json (`{ "someKey": "someValue" }`) rather than escaped string representations (`{ \"someKey\": \"someValue\" }`)

Add postman collection and environment for interacting with the API.

## To Test:
1. pre-configure a smart card (as a voter, or a poll worker, or whatever) and connect it to the reader
2. load the [postman](https://www.getpostman.com/) environment and collection
3. execute the requests

note you may have to turn off `settings > ssl certificate validation` in postman