### PR TITLE
build(dev): add Docker infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,11 @@ jobs:
       - run:
           name: Run Python Tests and Coverage
           command: |
-            pipenv run make coverage
+            make coverage
       - run:
           name: Run Mypy Type Checking
           command: |
-            pipenv run make typecheck
+            make typecheck
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.7.3
+RUN pip install --upgrade pip
+RUN pip install pipenv
+RUN apt-get update
+RUN apt-get install -y \
+    libpcsclite-dev \
+    libusb-1.0-0-dev \
+    pcsc-tools \
+    pcscd \
+    swig
+RUN mkdir /code
+WORKDIR /code
+COPY Pipfile Pipfile.lock /code/
+RUN pipenv install --dev

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ install-dev-dependencies:
 build: install install-dependencies
 
 test:
-	python3 -m pytest
+	python3 -m pipenv run python -m pytest
 
 coverage:
-	python3 -m pytest --cov=smartcards --cov-report term-missing --cov-fail-under=100 tests/
+	python3 -m pipenv run python -m pytest --cov=smartcards --cov-report term-missing --cov-fail-under=100 tests/
 
 typecheck:
-	python3 -m mypy smartcards tests
+	python3 -m pipenv run python -m mypy smartcards tests
 
 run:
-	FLASK_APP=smartcards.core python3 -m pipenv run python -m flask run --port 3001
+	FLASK_APP=smartcards.core python3 -m pipenv run python -m flask run --port 3001 --host 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 This web server component provides a web interface to a connected smartcard.
 
+## Prerequisites
+
+The instructions below show how to run this web server either directly or via Docker. If you wish to use Docker, make sure both [`docker`](https://docs.docker.com/install/) and [`docker-compose`](https://docs.docker.com/compose/install/) are installed. Otherwise the instructions assume you're running in [Ubuntu](http://ubuntu.com), though other systems such as macOS work with appropriate changes.
+
 ## Install Requisite Software
 
-```
+```sh
+# without docker only -- docker handles this for you
 sudo add-apt-repository ppa:deadsnakes/ppa
-
 sudo make install
 make build
 ```
@@ -15,26 +19,41 @@ make build
 
 Install dependencies you need
 
-```
+```sh
+# without docker only -- docker handles this for you
 make install-dev-dependencies
 ```
 
 and then run the tests
 
-```
+```sh
+# without docker
 make test
+
+# with docker
+docker-compose run server-tests make test
 ```
 
 With code coverage
 
-```
+```sh
+# without docker
 make coverage
+
+# with docker
+docker-compose run server-tests make coverage
 ```
 
 ## Start the Development Server
 
-```
+The server will be available at http://localhost:3001/.
+
+```sh
+# without docker
 make run
+
+# with docker
+docker-compose up
 ```
 
 ## Mock a Smart Card

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This web server component provides a web interface to a connected smartcard.
 
 The instructions below show how to run this web server either directly or via Docker. If you wish to use Docker, make sure both [`docker`](https://docs.docker.com/install/) and [`docker-compose`](https://docs.docker.com/compose/install/) are installed. Otherwise the instructions assume you're running in [Ubuntu](http://ubuntu.com), though other systems such as macOS work with appropriate changes.
 
+> **Note:** While using Docker is a great way to get this running with mock data for developing BMD, it's not straightforward to use Docker with real hardware. You can use both development approaches interchangeably, so pick the one that is most appropriate to the task at hand.
+
 ## Install Requisite Software
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  # API server
+  server:
+    build: .
+    command: make run
+    ports:
+      - 3001:3001
+    volumes:
+      - .:/code
+    environment:
+      FLASK_ENV: development
+    restart: on-failure
+
+  # this is here as a way to run server tests easily
+  server-tests:
+    build: .
+    command: /bin/true
+    volumes:
+      - .:/code
+    environment:
+      FLASK_ENV: test
+    depends_on:
+      - server


### PR DESCRIPTION

This commit adds the ability to develop module-smartcards using Docker as an alternative approach. This does not replace the existing approach, just makes a new one available.

The main advantages are reproducibility and isolation of development environment, ease of installing dependencies regardless of the host system, and ease of orchestrating development processes. The main disadvantages are adding indirection to development systems and adding reliance on yet more software (Docker).