### PR TITLE
build: install python & smartcard tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install-dependencies:
 install-dev-dependencies:
 	python3 -m pipenv install --dev
 
-build: install-dependencies
+build: install install-dependencies
 
 test:
 	python3 -m pytest


### PR DESCRIPTION
Without this it fails to build properly if python3 et al haven't already been installed.